### PR TITLE
refactor: switch WeeklyEnergyChart to area chart

### DIFF
--- a/solarpal-frontend/src/components/charts/WeeklyEnergyChart.jsx
+++ b/solarpal-frontend/src/components/charts/WeeklyEnergyChart.jsx
@@ -1,10 +1,22 @@
 import { useEffect, useMemo, useState } from "react";
 import Card from "../ui/Card";
-import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, Legend } from "recharts";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Legend,
+  ReferenceLine,
+} from "recharts";
 // If you prefer to call the backend via your service wrapper:
 import { fetchForecast } from "../../services/solarApi";
 
-export default function WeeklyEnergyChart({ userId, systemSize = 5 }) {
+export default function WeeklyEnergyChart({ summary }) {
+  const userId = summary?.user_id;
+  const systemSize = summary?.system_size_kw ?? 5;
   const [daily, setDaily] = useState([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState("");
@@ -36,6 +48,12 @@ export default function WeeklyEnergyChart({ userId, systemSize = 5 }) {
     }));
   }, [daily]);
 
+  const avgKwh = useMemo(() => {
+    if (chartData.length === 0) return 0;
+    const total = chartData.reduce((sum, d) => sum + d.kwh, 0);
+    return total / chartData.length;
+  }, [chartData]);
+
   return (
     <Card>
       <h2 style={{ marginBottom: 8 }}>Weekly Energy Forecast</h2>
@@ -47,7 +65,10 @@ export default function WeeklyEnergyChart({ userId, systemSize = 5 }) {
       {!loading && !err && chartData.length > 0 && (
         <div style={{ width: "100%", height: 260 }}>
           <ResponsiveContainer>
-            <LineChart data={chartData} margin={{ top: 10, right: 16, bottom: 0, left: -10 }}>
+            <AreaChart
+              data={chartData}
+              margin={{ top: 10, right: 16, bottom: 0, left: -10 }}
+            >
               <defs>
                 <linearGradient id="kwhGrad" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="0%" stopColor="#0ea5e9" stopOpacity={0.9} />
@@ -58,16 +79,23 @@ export default function WeeklyEnergyChart({ userId, systemSize = 5 }) {
               <XAxis dataKey="day" />
               <YAxis tickFormatter={(v) => `${v}`} />
               <Tooltip formatter={(v) => [`${v} kWh`, "Energy"]} />
+              <ReferenceLine
+                y={avgKwh}
+                stroke="#888"
+                strokeDasharray="3 3"
+                label="Avg"
+              />
               <Legend />
-              <Line
+              <Area
                 type="monotone"
                 dataKey="kwh"
                 stroke="#0ea5e9"
                 strokeWidth={2.5}
                 dot={{ r: 3 }}
                 activeDot={{ r: 5 }}
+                fill="url(#kwhGrad)"
               />
-            </LineChart>
+            </AreaChart>
           </ResponsiveContainer>
         </div>
       )}


### PR DESCRIPTION
## Summary
- switch forecast chart to AreaChart with gradient and average reference line
- derive chart params from `summary` prop

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 14 errors in unrelated files)*
- `npx eslint src/components/charts/WeeklyEnergyChart.jsx`
- `npm run build` *(fails: Could not resolve "./components/Dashboard" from "src/App.jsx")*

------
https://chatgpt.com/codex/tasks/task_e_68ad01e39a88832a98234aed11111800