### PR TITLE
Add error boundaries and request retry handling

### DIFF
--- a/solarpal-frontend/src/App.jsx
+++ b/solarpal-frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import Onboarding from "./components/Onboarding";
 import Dashboard from "./components/Dashboard";
+import ErrorBoundary from "./components/ui/ErrorBoundary";
 import { loadState, saveState, clearState } from "./lib/storage";
 
 export default function App() {
@@ -31,8 +32,12 @@ export default function App() {
   };
 
   return appStage === "onboarding" ? (
-    <Onboarding onSuccess={handleOnboardingSuccess} />
+    <ErrorBoundary>
+      <Onboarding onSuccess={handleOnboardingSuccess} />
+    </ErrorBoundary>
   ) : (
-    <Dashboard data={dashboardData} onReset={handleReset} />
+    <ErrorBoundary>
+      <Dashboard data={dashboardData} onReset={handleReset} />
+    </ErrorBoundary>
   );
 }

--- a/solarpal-frontend/src/components/Onboarding.jsx
+++ b/solarpal-frontend/src/components/Onboarding.jsx
@@ -12,8 +12,7 @@ export default function Onboarding({ onSuccess }) {
   const onChange = (e) =>
     setForm((f) => ({ ...f, [e.target.name]: e.target.value }));
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
+  const requestSummary = async () => {
     setError("");
     if (!form.userId?.trim()) {
       setError("Please enter your user ID.");
@@ -28,6 +27,15 @@ export default function Onboarding({ onSuccess }) {
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    requestSummary();
+  };
+
+  const handleRetry = () => {
+    requestSummary();
   };
 
   return (
@@ -50,7 +58,14 @@ export default function Onboarding({ onSuccess }) {
               />
             </div>
 
-            {error && <p style={{ color: "#b00020", marginTop: 8 }}>{error}</p>}
+            {error && (
+              <div style={{ color: "#b00020", marginTop: 8 }}>
+                <p>{error}</p>
+                <Button type="button" onClick={handleRetry} disabled={loading} style={{ marginTop: 8 }}>
+                  Retry
+                </Button>
+              </div>
+            )}
 
             <div style={{ marginTop: 16 }}>
               <Button type="submit" disabled={loading}>

--- a/solarpal-frontend/src/components/charts/WeeklyEnergyChart.jsx
+++ b/solarpal-frontend/src/components/charts/WeeklyEnergyChart.jsx
@@ -1,32 +1,35 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import Card from "../ui/Card";
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, Legend } from "recharts";
 // If you prefer to call the backend via your service wrapper:
 import { fetchForecast } from "../../services/solarApi";
+import ErrorBoundary from "../ui/ErrorBoundary";
 
-export default function WeeklyEnergyChart({ userId, systemSize = 5 }) {
+export default function WeeklyEnergyChart({ summary, userId, systemSize = 5 }) {
   const [daily, setDaily] = useState([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState("");
+  const uid = userId ?? summary?.user_id;
+
+  const loadForecast = useCallback(async () => {
+    if (!uid) return;
+    setLoading(true);
+    setErr("");
+    try {
+      // NOTE: Our backend currently accepts "location" — we’re passing userId as a stand-in.
+      const data = await fetchForecast({ location: uid, systemSize });
+      setDaily(Array.isArray(data?.daily) ? data.daily : []);
+    } catch (e) {
+      setErr(e?.message || "Failed to load forecast");
+      setDaily([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [uid, systemSize]);
 
   useEffect(() => {
-    if (!userId) return;
-
-    (async () => {
-      setLoading(true);
-      setErr("");
-      try {
-        // NOTE: Our backend currently accepts "location" — we’re passing userId as a stand-in.
-        const data = await fetchForecast({ location: userId, systemSize });
-        setDaily(Array.isArray(data?.daily) ? data.daily : []);
-      } catch (e) {
-        setErr(e?.message || "Failed to load forecast");
-        setDaily([]);
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [userId, systemSize]);
+    loadForecast();
+  }, [loadForecast]);
 
   const chartData = useMemo(() => {
     // Normalize to { day: 'Mon', kwh: number }
@@ -37,41 +40,48 @@ export default function WeeklyEnergyChart({ userId, systemSize = 5 }) {
   }, [daily]);
 
   return (
-    <Card>
-      <h2 style={{ marginBottom: 8 }}>Weekly Energy Forecast</h2>
+    <ErrorBoundary>
+      <Card>
+        <h2 style={{ marginBottom: 8 }}>Weekly Energy Forecast</h2>
 
-      {loading && <p>Loading forecast…</p>}
-      {!loading && err && <p>⚠️ {err}</p>}
-      {!loading && !err && chartData.length === 0 && <p>No forecast available.</p>}
+        {loading && <p>Loading forecast…</p>}
+        {!loading && err && (
+          <div>
+            <p>⚠️ {err}</p>
+            <button onClick={loadForecast}>Retry</button>
+          </div>
+        )}
+        {!loading && !err && chartData.length === 0 && <p>No forecast available.</p>}
 
-      {!loading && !err && chartData.length > 0 && (
-        <div style={{ width: "100%", height: 260 }}>
-          <ResponsiveContainer>
-            <LineChart data={chartData} margin={{ top: 10, right: 16, bottom: 0, left: -10 }}>
-              <defs>
-                <linearGradient id="kwhGrad" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="#0ea5e9" stopOpacity={0.9} />
-                  <stop offset="100%" stopColor="#0ea5e9" stopOpacity={0.2} />
-                </linearGradient>
-              </defs>
-              <CartesianGrid strokeDasharray="3 3" opacity={0.4} />
-              <XAxis dataKey="day" />
-              <YAxis tickFormatter={(v) => `${v}`} />
-              <Tooltip formatter={(v) => [`${v} kWh`, "Energy"]} />
-              <Legend />
-              <Line
-                type="monotone"
-                dataKey="kwh"
-                stroke="#0ea5e9"
-                strokeWidth={2.5}
-                dot={{ r: 3 }}
-                activeDot={{ r: 5 }}
-              />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-      )}
-    </Card>
+        {!loading && !err && chartData.length > 0 && (
+          <div style={{ width: "100%", height: 260 }}>
+            <ResponsiveContainer>
+              <LineChart data={chartData} margin={{ top: 10, right: 16, bottom: 0, left: -10 }}>
+                <defs>
+                  <linearGradient id="kwhGrad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#0ea5e9" stopOpacity={0.9} />
+                    <stop offset="100%" stopColor="#0ea5e9" stopOpacity={0.2} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" opacity={0.4} />
+                <XAxis dataKey="day" />
+                <YAxis tickFormatter={(v) => `${v}`} />
+                <Tooltip formatter={(v) => [`${v} kWh`, "Energy"]} />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey="kwh"
+                  stroke="#0ea5e9"
+                  strokeWidth={2.5}
+                  dot={{ r: 3 }}
+                  activeDot={{ r: 5 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </Card>
+    </ErrorBoundary>
   );
 }
 

--- a/solarpal-frontend/src/components/dashboard/Dashboard.jsx
+++ b/solarpal-frontend/src/components/dashboard/Dashboard.jsx
@@ -1,5 +1,5 @@
 // src/components/Dashboard.jsx
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 
 // services
 import { fetchForecast, getWeather } from "../../services/solarApi";
@@ -14,6 +14,7 @@ import SummaryCard from "./SummaryCard";
 import TipCard from "./TipCard";
 import WeeklyEnergyChart from "../charts/WeeklyEnergyChart";
 import PremiumTeaser from "./PremiumTeaser";
+import ErrorBoundary from "../ui/ErrorBoundary";
 
 // 3D scene
 import HouseScene from "../HouseScene";
@@ -21,72 +22,82 @@ import HouseScene from "../HouseScene";
 export default function Dashboard({ data, onReset }) {
   const [forecast, setForecast] = useState(null);
   const [weather, setWeather] = useState(null);
+  const [forecastErr, setForecastErr] = useState("");
+  const [weatherErr, setWeatherErr] = useState("");
 
-  if (!data) return null;
-  const summary = data.summary ?? data;
+  const summary = data?.summary ?? data;
   const isPremium = false; // TODO: replace with real auth/subscription
 
-  useEffect(() => {
+  const loadData = useCallback(async () => {
     if (!data) {
       onReset?.();
       return;
     }
+    setForecastErr("");
+    setWeatherErr("");
+    try {
+      const fc = await fetchForecast({
+        location: summary.location ?? data.location ?? "",
+        systemSize: summary.system_size_kw ?? 5,
+      });
+      setForecast(fc);
+    } catch (e) {
+      setForecastErr(e.message);
+    }
 
-    (async () => {
-      try {
-        // 1) Fetch solar forecast for charts / future use
-        const fc = await fetchForecast({
-          location: summary.location ?? data.location ?? "",
-          systemSize: summary.system_size_kw ?? 5,
-        });
-        setForecast(fc);
-      } catch (e) {
-        console.warn("Forecast failed:", e.message);
-      }
+    if ("geolocation" in navigator) {
+      navigator.geolocation.getCurrentPosition(
+        async (pos) => {
+          try {
+            const w = await getWeather(pos.coords.latitude, pos.coords.longitude);
+            setWeather(w);
+          } catch (err) {
+            setWeatherErr(err.message);
+          }
+        },
+        (err) => {
+          setWeatherErr(err.message);
+        },
+        { enableHighAccuracy: false, timeout: 8000 }
+      );
+    }
+  }, [data, onReset, summary?.location, summary?.system_size_kw]);
 
-      // 2) Fetch live weather for 3D scene (if user allows location)
-      if ("geolocation" in navigator) {
-        navigator.geolocation.getCurrentPosition(
-          async (pos) => {
-            try {
-              const w = await getWeather(pos.coords.latitude, pos.coords.longitude);
-              setWeather(w);
-            } catch (err) {
-              console.warn("getWeather failed:", err?.message);
-            }
-          },
-          (err) => {
-            console.warn("Geolocation denied:", err?.message);
-            // Optional: fallback — use summary.location on backend to fetch weather by name
-          },
-          { enableHighAccuracy: false, timeout: 8000 }
-        );
-      }
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, onReset, summary.location, summary.system_size_kw]);
+  useEffect(() => {
+    if (data) loadData();
+  }, [data, loadData]);
+
+  if (!data) return null;
 
   return (
-    <CloudBackground>
-      <Header onReset={onReset} />
+    <ErrorBoundary>
+      <CloudBackground>
+        <Header onReset={onReset} />
 
-      <main style={{ maxWidth: 980, margin: "12px auto 40px", padding: "0 16px" }}>
-        <h1 style={{ fontSize: 28, marginBottom: 8 }}>Dashboard</h1>
+        <main style={{ maxWidth: 980, margin: "12px auto 40px", padding: "0 16px" }}>
+          <h1 style={{ fontSize: 28, marginBottom: 8 }}>Dashboard</h1>
 
-        <SummaryCard userId={summary.user_id} />
-        <TipCard userId={summary.user_id} />
+          <SummaryCard userId={summary.user_id} />
+          <TipCard userId={summary.user_id} />
 
+          {/* Free mini chart (synth or real when available) */}
+          <WeeklyEnergyChart summary={summary} />
 
-        {/* Free mini chart (synth or real when available) */}
-        <WeeklyEnergyChart summary={summary} />
+          {/* Interactive 3D house + weather animations */}
+          <Card style={{ marginTop: 12, padding: 0 }}>
+            {forecastErr || weatherErr ? (
+              <div style={{ padding: 16 }}>
+                <p>⚠️ {forecastErr || weatherErr}</p>
+                <button onClick={loadData}>Retry</button>
+              </div>
+            ) : (
+              <HouseScene height={380} forecast={forecast} weather={weather} />
+            )}
+          </Card>
 
-        {/* Interactive 3D house + weather animations */}
-        <Card style={{ marginTop: 12, padding: 0 }}>
-          <HouseScene height={380} forecast={forecast} weather={weather} />
-        </Card>
-
-        {!isPremium && <PremiumTeaser />}
-      </main>
-    </CloudBackground>
+          {!isPremium && <PremiumTeaser />}
+        </main>
+      </CloudBackground>
+    </ErrorBoundary>
   );
 }

--- a/solarpal-frontend/src/components/ui/ErrorBoundary.jsx
+++ b/solarpal-frontend/src/components/ui/ErrorBoundary.jsx
@@ -1,0 +1,41 @@
+import { Component, cloneElement } from "react";
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+    this.reset = this.reset.bind(this);
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("ErrorBoundary caught error", error, info);
+  }
+
+  reset() {
+    this.setState({ error: null });
+    this.props.onReset?.();
+  }
+
+  render() {
+    if (this.state.error) {
+      const { fallback } = this.props;
+      if (typeof fallback === "function") {
+        return fallback({ error: this.state.error, reset: this.reset });
+      }
+      if (fallback) {
+        return cloneElement(fallback, { retry: this.reset });
+      }
+      return (
+        <div style={{ padding: 16 }}>
+          <p>Something went wrong.</p>
+          <button onClick={this.reset}>Retry</button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/solarpal-frontend/src/services/solarApi.js
+++ b/solarpal-frontend/src/services/solarApi.js
@@ -16,24 +16,40 @@ api.interceptors.response.use(
   }
 );
 
+export async function retryRequest(fn, maxAttempts = 3) {
+  let lastErr;
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr;
+}
+
 // Used by Onboarding
 export async function fetchSummary(userId) {
-  const res = await api.get("/summary", {
-    params: { user_id: userId },
-  });
+  const res = await retryRequest(() =>
+    api.get("/summary", { params: { user_id: userId } })
+  );
   return res.data;
 }
 
 // Used by Dashboard – solar forecast for charts / future use
 export async function fetchForecast({ location, systemSize }) {
-  const res = await api.get("/forecast", {
-    params: { location, system_size: systemSize },
-  });
+  const res = await retryRequest(() =>
+    api.get("/forecast", {
+      params: { location, system_size: systemSize },
+    })
+  );
   return res.data;
 }
 
 // Used by 3D weather scene – live weather by coordinates
 export async function getWeather(lat, lon) {
-  const res = await api.get("/weather", { params: { lat, lon } });
+  const res = await retryRequest(() =>
+    api.get("/weather", { params: { lat, lon } })
+  );
   return res.data;
 }


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` component with reset capability
- wrap App routes, Dashboard, and WeeklyEnergyChart in error boundaries
- add `retryRequest` helper and surface retry buttons on failed API calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 11 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68ad02e6e1bc832aacb699b17fb1a3ec