### PR TITLE
fix: adjust dashboard import path

### DIFF
--- a/solarpal-frontend/src/App.jsx
+++ b/solarpal-frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Onboarding from "./components/Onboarding";
-import Dashboard from "./components/Dashboard";
+import Dashboard from "./components/dashboard/Dashboard";
 import { loadState, saveState, clearState } from "./lib/storage";
 
 export default function App() {


### PR DESCRIPTION
## Summary
- update App.jsx to import Dashboard from nested components directory

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad05ea9778832ab2062f84a03cf3c4