### PR TITLE
Label average line in weekly energy chart

### DIFF
--- a/solarpal-frontend/src/components/charts/WeeklyEnergyChart.jsx
+++ b/solarpal-frontend/src/components/charts/WeeklyEnergyChart.jsx
@@ -87,7 +87,12 @@ export default function WeeklyEnergyChart({ summary }) {
               <YAxis tickFormatter={(v) => `${v}`} />
               <Tooltip formatter={(v) => [`${v} kWh`, "Energy"]} />
               <Legend />
-              <ReferenceLine y={avgKwh} stroke="#f87171" strokeDasharray="3 3" />
+              <ReferenceLine
+                y={avgKwh}
+                stroke="#f87171"
+                strokeDasharray="3 3"
+                label="Avg"
+              />
               <Area
                 type="monotone"
                 dataKey="kwh"


### PR DESCRIPTION
## Summary
- derive chart data from summary props and compute average kWh
- switch to AreaChart with gradient and mark average with labeled reference line
- ensure dashboard passes only summary to WeeklyEnergyChart

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 7 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68ad05e7f780832aa118a27c597dbd96