### PR TITLE
Restore weekly energy chart and dashboard integration

### DIFF
--- a/solarpal-frontend/src/components/charts/WeeklyEnergyChart.jsx
+++ b/solarpal-frontend/src/components/charts/WeeklyEnergyChart.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useState } from "react";
+import Card from "../ui/Card";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Legend,
+  ReferenceLine,
+} from "recharts";
+// If you prefer to call the backend via your service wrapper:
+import { fetchForecast } from "../../services/solarApi";
+
+export default function WeeklyEnergyChart({ summary }) {
+  const userId = summary?.user_id;
+  const systemSize = summary?.system_size_kw ?? 5;
+  const [daily, setDaily] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState("");
+  const [isNarrow, setIsNarrow] = useState(false);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    (async () => {
+      setLoading(true);
+      setErr("");
+      try {
+        // NOTE: Our backend currently accepts "location" — we’re passing userId as a stand-in.
+        const data = await fetchForecast({ location: userId, systemSize });
+        setDaily(Array.isArray(data?.daily) ? data.daily : []);
+      } catch (e) {
+        setErr(e?.message || "Failed to load forecast");
+        setDaily([]);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [userId, systemSize]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia("(max-width: 500px)");
+    const handler = (e) => setIsNarrow(e.matches);
+    handler(mq);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const chartData = useMemo(() => {
+    // Normalize to { day: 'Mon', kwh: number }
+    return daily.map((d) => ({
+      day: formatDay(d.date),
+      kwh: Number(d.kwh ?? d.energy_kwh ?? 0),
+    }));
+  }, [daily]);
+
+  const avgKwh = useMemo(() => {
+    if (chartData.length === 0) return 0;
+    return (
+      chartData.reduce((sum, d) => sum + d.kwh, 0) / chartData.length
+    );
+  }, [chartData]);
+
+  return (
+    <Card>
+      <h2 style={{ marginBottom: 8 }}>Weekly Energy Forecast</h2>
+
+      {loading && <p>Loading forecast…</p>}
+      {!loading && err && <p>⚠️ {err}</p>}
+      {!loading && !err && chartData.length === 0 && <p>No forecast available.</p>}
+
+      {!loading && !err && chartData.length > 0 && (
+        <ResponsiveContainer width="100%" height={isNarrow ? 200 : 260}>
+          <AreaChart data={chartData} margin={{ top: 10, right: 16, bottom: 0, left: -10 }}>
+              <defs>
+                <linearGradient id="kwhGrad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#0ea5e9" stopOpacity={0.9} />
+                  <stop offset="100%" stopColor="#0ea5e9" stopOpacity={0.2} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" opacity={0.4} />
+              <XAxis dataKey="day" />
+              <YAxis tickFormatter={(v) => `${v}`} />
+              <Tooltip formatter={(v) => [`${v} kWh`, "Energy"]} />
+              <Legend />
+              <ReferenceLine y={avgKwh} stroke="#f87171" strokeDasharray="3 3" />
+              <Area
+                type="monotone"
+                dataKey="kwh"
+                stroke="#0ea5e9"
+                strokeWidth={2.5}
+                fill="url(#kwhGrad)"
+              />
+          </AreaChart>
+        </ResponsiveContainer>
+      )}
+    </Card>
+  );
+}
+
+function formatDay(dateStr) {
+  try {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString(undefined, { weekday: "short" }); // Mon, Tue…
+  } catch {
+    return dateStr ?? "";
+  }
+}

--- a/solarpal-frontend/src/components/dashboard/Dashboard.jsx
+++ b/solarpal-frontend/src/components/dashboard/Dashboard.jsx
@@ -1,0 +1,94 @@
+// src/components/Dashboard.jsx
+import { useEffect, useState } from "react";
+
+// services
+import { fetchForecast, getWeather } from "../../services/solarApi";
+
+// layout / ui
+import CloudBackground from "../CloudBackground";
+import Header from "../Header";
+import Card from "../ui/Card";
+
+// dashboard pieces
+import SummaryCard from "./SummaryCard";
+import TipCard from "./TipCard";
+import ROICard from "./ROICard";
+import WeeklyEnergyChart from "../charts/WeeklyEnergyChart";
+import PremiumTeaser from "./PremiumTeaser";
+
+// 3D scene
+import HouseScene from "../HouseScene";
+
+export default function Dashboard({ data, onReset }) {
+  const [forecast, setForecast] = useState(null);
+  const [weather, setWeather] = useState(null);
+
+  const summary = data?.summary ?? data;
+  const isPremium = false; // TODO: replace with real auth/subscription
+
+  useEffect(() => {
+    if (!data) {
+      onReset?.();
+      return;
+    }
+
+    (async () => {
+      try {
+        // 1) Fetch solar forecast for charts / future use
+        const fc = await fetchForecast({
+          location: summary.location ?? data.location ?? "",
+          systemSize: summary.system_size_kw ?? 5,
+        });
+        setForecast(fc);
+      } catch (e) {
+        console.warn("Forecast failed:", e.message);
+      }
+
+      // 2) Fetch live weather for 3D scene (if user allows location)
+      if ("geolocation" in navigator) {
+        navigator.geolocation.getCurrentPosition(
+          async (pos) => {
+            try {
+              const w = await getWeather(pos.coords.latitude, pos.coords.longitude);
+              setWeather(w);
+            } catch (err) {
+              console.warn("getWeather failed:", err?.message);
+            }
+          },
+          (err) => {
+            console.warn("Geolocation denied:", err?.message);
+            // Optional: fallback — use summary.location on backend to fetch weather by name
+          },
+          { enableHighAccuracy: false, timeout: 8000 }
+        );
+      }
+    })();
+  }, [data, onReset, summary?.location, summary?.system_size_kw]);
+
+  if (!data) return null;
+
+  return (
+    <CloudBackground>
+      <Header onReset={onReset} />
+
+      <main className="max-w-screen-lg mx-auto mt-3 mb-10 px-4 sm:px-6">
+        <h1 className="text-2xl sm:text-3xl mb-2">Dashboard</h1>
+
+        <SummaryCard userId={summary.user_id} />
+        <TipCard userId={summary.user_id} />
+        <ROICard userId={summary.user_id} />
+
+
+        {/* Free mini chart (synth or real when available) */}
+        <WeeklyEnergyChart summary={summary} />
+
+        {/* Interactive 3D house + weather animations */}
+        <Card style={{ marginTop: 12, padding: 0 }}>
+          <HouseScene height={380} forecast={forecast} weather={weather} />
+        </Card>
+
+        {!isPremium && <PremiumTeaser />}
+      </main>
+    </CloudBackground>
+  );
+}


### PR DESCRIPTION
## Summary
- Recover WeeklyEnergyChart component that derives `userId` and `systemSize` from a `summary` prop and visualizes data with an AreaChart and weekly average reference line
- Restore Dashboard component to pass `summary` only to WeeklyEnergyChart

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 7 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0a5af524832a9a42f6247062b461