### PR TITLE
Add dashboard component and fix forecast export

### DIFF
--- a/solarpal-frontend/src/components/dashboard/Dashboard.jsx
+++ b/solarpal-frontend/src/components/dashboard/Dashboard.jsx
@@ -1,0 +1,32 @@
+import CloudBackground from "../CloudBackground";
+import Header from "../Header";
+import SummaryCard from "./SummaryCard";
+import ROICard from "./ROICard";
+import TipCard from "./TipCard";
+import PremiumTeaser from "./PremiumTeaser";
+
+export default function Dashboard({ data, onReset }) {
+  const userId = data?.user_id;
+
+  return (
+    <CloudBackground>
+      <Header onReset={onReset} />
+      <div
+        style={{
+          maxWidth: 560,
+          margin: "0 auto",
+          padding: "32px 16px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 20
+        }}
+      >
+        <SummaryCard userId={userId} />
+        <ROICard userId={userId} />
+        <TipCard userId={userId} />
+        <PremiumTeaser />
+      </div>
+    </CloudBackground>
+  );
+}
+

--- a/solarpal-frontend/src/services/solarApi.js
+++ b/solarpal-frontend/src/services/solarApi.js
@@ -38,16 +38,6 @@ export async function getWeather(lat, lon) {
   return res.data;
 }
 
-export async function fetchForecast({ location, systemSize }) {
-  // If your router is prefixed (e.g., /solar/forecast), update the path here.
-  const baseURL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
-  const res = await fetch(
-    `${baseURL}/forecast?location=${encodeURIComponent(location)}&system_size=${systemSize}`
-  );
-  if (!res.ok) throw new Error("Forecast request failed");
-  return res.json();
-}
-
 export function normalizeWeather(openWeatherJson) {
   if (!openWeatherJson) return null;
   const ow = openWeatherJson;


### PR DESCRIPTION
## Summary
- Reintroduce Dashboard component that composes summary, ROI, tip and premium teaser cards
- Remove duplicate `fetchForecast` function in solarApi to resolve build error

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Several lint errors in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad0a5bf90c832aaa0da4e9ce800c1a