### PR TITLE
Pass summary to WeeklyEnergyChart

### DIFF
--- a/solarpal-frontend/src/components/dashboard/Dashboard.jsx
+++ b/solarpal-frontend/src/components/dashboard/Dashboard.jsx
@@ -114,10 +114,7 @@ function Dashboard({ data, onReset }) {
         <ROICard userId={summary.user_id} />
 
         {/* Free mini chart */}
-        <WeeklyEnergyChart
-          userId={summary.user_id}
-          systemSize={summary.system_size_kw ?? 5}
-        />
+        <WeeklyEnergyChart summary={summary} />
 
         {/* Interactive 3D house + weather animations */}
         <Card style={{ marginTop: 12, padding: 0 }}>


### PR DESCRIPTION
## Summary
- Simplify dashboard chart usage by passing full summary object to WeeklyEnergyChart.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars and other errors in existing files)*
- `npm run build` *(fails: duplicate fetchForecast export in services/solarApi.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0db0f368832a80ec88eed9945c45