### PR TITLE
Refactor weather API interface

### DIFF
--- a/solarpal-frontend/src/services/solarApi.js
+++ b/solarpal-frontend/src/services/solarApi.js
@@ -33,19 +33,9 @@ export async function fetchForecast({ location, systemSize }) {
 }
 
 // Used by 3D weather scene – live weather by coordinates
-export async function getWeather(lat, lon) {
-  const res = await api.get("/weather", { params: { lat, lon } });
+export async function getWeather({ lat, lon, units }) {
+  const res = await api.get("/weather", { params: { lat, lon, units } });
   return res.data;
-}
-
-export async function fetchForecast({ location, systemSize }) {
-  // If your router is prefixed (e.g., /solar/forecast), update the path here.
-  const baseURL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
-  const res = await fetch(
-    `${baseURL}/forecast?location=${encodeURIComponent(location)}&system_size=${systemSize}`
-  );
-  if (!res.ok) throw new Error("Forecast request failed");
-  return res.json();
 }
 
 export function normalizeWeather(openWeatherJson) {


### PR DESCRIPTION
## Summary
- remove duplicate `fetchForecast` and rely solely on axios implementation
- refactor `getWeather` to accept `{lat, lon, units}` and forward params in axios request

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npx eslint src/services/solarApi.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad0db702f4832a8b11160c9c4b284d