### PR TITLE
refactor: centralize solar api helpers and cards

### DIFF
--- a/solarpal-frontend/src/components/dashboard/SummaryCard.jsx
+++ b/solarpal-frontend/src/components/dashboard/SummaryCard.jsx
@@ -1,28 +1,32 @@
 import { useEffect, useState } from "react";
 import Card from "../ui/Card";
+import { fetchSummary } from "../../services/solarApi";
 
 export default function SummaryCard({ userId }) {
   const [summary, setSummary] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (!userId) return;
 
-    const fetchSummary = async () => {
+    const loadSummary = async () => {
       try {
         setLoading(true);
-        const res = await fetch(`http://localhost:8000/summary?user_id=${userId}`);
-        const data = await res.json();
-        setSummary(data.summary ?? data); // handle both wrapped & raw
+        setError(null);
+        const data = await fetchSummary(userId);
+        if (!data) throw new Error("Summary unavailable");
+        setSummary(data);
       } catch (e) {
         console.warn("Failed to load summary:", e);
+        setError(e.message || "Couldn’t fetch your summary.");
         setSummary(null);
       } finally {
         setLoading(false);
       }
     };
 
-    fetchSummary();
+    loadSummary();
   }, [userId]);
 
   return (
@@ -30,8 +34,8 @@ export default function SummaryCard({ userId }) {
       <h2 style={{ marginBottom: 8 }}>System Summary</h2>
       {loading ? (
         <p>Loading summary…</p>
-      ) : !summary ? (
-        <p>⚠️ Couldn’t fetch your summary.</p>
+      ) : error ? (
+        <p>⚠️ {error}</p>
       ) : (
         <ul style={{ lineHeight: 1.6 }}>
           <li><b>User ID:</b> {summary.user_id}</li>

--- a/solarpal-frontend/src/components/dashboard/TipCard.jsx
+++ b/solarpal-frontend/src/components/dashboard/TipCard.jsx
@@ -1,28 +1,31 @@
 import { useEffect, useState } from "react";
 import Card from "../ui/Card";
+import { fetchTip } from "../../services/solarApi";
 
 export default function TipCard({ userId }) {
   const [tip, setTip] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (!userId) return;
 
-    const fetchTip = async () => {
+    const loadTip = async () => {
       try {
         setLoading(true);
-        const res = await fetch(`http://localhost:8000/tips?user_id=${userId}`);
-        const data = await res.json();
-        setTip(data.tip ?? "No tip available right now.");
+        setError(null);
+        const data = await fetchTip(userId);
+        setTip(data ?? "No tip available right now.");
       } catch (e) {
         console.warn("Failed to load tip:", e);
-        setTip("⚠️ Couldn’t fetch your solar tip.");
+        setError(e.message || "Couldn’t fetch your solar tip.");
+        setTip(null);
       } finally {
         setLoading(false);
       }
     };
 
-    fetchTip();
+    loadTip();
   }, [userId]);
 
   return (
@@ -30,6 +33,8 @@ export default function TipCard({ userId }) {
       <h2 style={{ marginBottom: 8 }}>Your Solar Tip</h2>
       {loading ? (
         <p>Loading tip…</p>
+      ) : error ? (
+        <p>⚠️ {error}</p>
       ) : (
         <p>{tip}</p>
       )}

--- a/solarpal-frontend/src/services/solarApi.js
+++ b/solarpal-frontend/src/services/solarApi.js
@@ -16,9 +16,25 @@ api.interceptors.response.use(
   }
 );
 
-// Used by Onboarding
+// Used by Onboarding and Dashboard summary card
 export async function fetchSummary(userId) {
   const res = await api.get("/summary", {
+    params: { user_id: userId },
+  });
+  return res.data?.summary ?? res.data;
+}
+
+// Dashboard – helpful solar tip for the user
+export async function fetchTip(userId) {
+  const res = await api.get("/tips", {
+    params: { user_id: userId },
+  });
+  return res.data?.tip ?? res.data;
+}
+
+// Dashboard – ROI metrics
+export async function fetchRoi(userId) {
+  const res = await api.get("/roi", {
     params: { user_id: userId },
   });
   return res.data;
@@ -36,16 +52,6 @@ export async function fetchForecast({ location, systemSize }) {
 export async function getWeather(lat, lon) {
   const res = await api.get("/weather", { params: { lat, lon } });
   return res.data;
-}
-
-export async function fetchForecast({ location, systemSize }) {
-  // If your router is prefixed (e.g., /solar/forecast), update the path here.
-  const baseURL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
-  const res = await fetch(
-    `${baseURL}/forecast?location=${encodeURIComponent(location)}&system_size=${systemSize}`
-  );
-  if (!res.ok) throw new Error("Forecast request failed");
-  return res.json();
 }
 
 export function normalizeWeather(openWeatherJson) {


### PR DESCRIPTION
## Summary
- add summary, tip, and ROI helpers using shared axios instance
- use service helpers in dashboard cards and unify error/loading states
- remove duplicate forecast fetch

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 7 problems (6 errors, 1 warning))*

------
https://chatgpt.com/codex/tasks/task_e_68ad0dba6284832a8874e0c2ea95a4f2