### PR TITLE
chore: remove unused imports from CloudBackground

### DIFF
--- a/solarpal-frontend/src/components/CloudBackground.jsx
+++ b/solarpal-frontend/src/components/CloudBackground.jsx
@@ -1,6 +1,3 @@
-import Sun from "./ui/Sun";
-import HouseGrid from "./HouseGrid";
-
 export default function CloudBackground({ children }) {
   return (
     <div style={{ minHeight: "100dvh", position: "relative" }}>


### PR DESCRIPTION
## Summary
- remove unused Sun and HouseGrid imports from CloudBackground component

## Testing
- `npm run lint` *(fails: existing errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0dbdba84832aa9c054ee2eef39ab