### PR TITLE
Simplify TipCard to use useTip hook

### DIFF
--- a/solarpal-frontend/src/components/dashboard/TipCard.jsx
+++ b/solarpal-frontend/src/components/dashboard/TipCard.jsx
@@ -3,47 +3,6 @@ import useTip from "../../hooks/useTip";
 
 export default function TipCard({ userId }) {
   const { tip, loading, error } = useTip(userId);
-import { fetchTip } from "../../services/solarApi";
-
-export default function TipCard({ userId }) {
-  const [tip, setTip] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  const load = async () => {
-    if (!userId) return;
-    try {
-      setLoading(true);
-      setError("");
-      const res = await fetch(`http://localhost:8000/tips?user_id=${userId}`);
-      const data = await res.json();
-      setTip(data.tip ?? "No tip available right now.");
-    } catch (e) {
-      console.warn("Failed to load tip:", e);
-      setError("Couldn’t fetch your solar tip.");
-      setTip(null);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-    const loadTip = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const data = await fetchTip(userId);
-        setTip(data ?? "No tip available right now.");
-      } catch (e) {
-        console.warn("Failed to load tip:", e);
-        setError(e.message || "Couldn’t fetch your solar tip.");
-        setTip(null);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadTip();
-  }, [userId]);
 
   return (
     <Card>
@@ -51,15 +10,11 @@ export default function TipCard({ userId }) {
       {loading ? (
         <p>Loading tip…</p>
       ) : error ? (
-        <div>
-          <p>⚠️ {error}</p>
-          <Button style={{ marginTop: 8 }} onClick={load}>
-            Retry
-          </Button>
-        </div>
+        <p>⚠️ {error.message || "Couldn’t fetch your solar tip."}</p>
       ) : (
         <p>{tip}</p>
       )}
     </Card>
   );
 }
+


### PR DESCRIPTION
## Summary
- Refactor TipCard to rely solely on the `useTip` hook
- Remove manual state and fetch logic, rendering only loading, error, or tip text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 9 errors, 3 warnings across repository)*
- `npx eslint src/components/dashboard/TipCard.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae03e6ffbc832aa0d61d9a5d2f1b98