### PR TITLE
Refactor hooks to use centralized solar API helpers

### DIFF
--- a/solarpal-frontend/src/hooks/useRoi.js
+++ b/solarpal-frontend/src/hooks/useRoi.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { fetchRoi } from "../services/solarApi";
 
 /**
  * Fetches ROI information for the user.
@@ -19,13 +20,11 @@ export default function useRoi(userId) {
 
     let cancelled = false;
 
-    async function fetchRoi() {
+    async function loadRoi() {
       try {
         setLoading(true);
         setError(null);
-        const res = await fetch(`http://localhost:8000/roi?user_id=${userId}`);
-        if (!res.ok) throw new Error("Failed to fetch ROI data");
-        const data = await res.json();
+        const data = await fetchRoi(userId);
         if (!cancelled) {
           setRoi(data);
         }
@@ -39,7 +38,7 @@ export default function useRoi(userId) {
       }
     }
 
-    fetchRoi();
+    loadRoi();
     return () => {
       cancelled = true;
     };

--- a/solarpal-frontend/src/hooks/useSummary.js
+++ b/solarpal-frontend/src/hooks/useSummary.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { fetchSummary } from "../services/solarApi";
 
 /**
  * Fetches the system summary for a given user.
@@ -19,14 +20,13 @@ export default function useSummary(userId) {
 
     let cancelled = false;
 
-    async function fetchSummary() {
+    async function loadSummary() {
       try {
         setLoading(true);
         setError(null);
-        const res = await fetch(`http://localhost:8000/summary?user_id=${userId}`);
-        const data = await res.json();
+        const data = await fetchSummary(userId);
         if (!cancelled) {
-          setSummary(data.summary ?? data);
+          setSummary(data);
         }
       } catch (err) {
         if (!cancelled) {
@@ -38,7 +38,7 @@ export default function useSummary(userId) {
       }
     }
 
-    fetchSummary();
+    loadSummary();
     return () => {
       cancelled = true;
     };

--- a/solarpal-frontend/src/hooks/useTip.js
+++ b/solarpal-frontend/src/hooks/useTip.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { fetchTip } from "../services/solarApi";
 
 /**
  * Retrieves a personalised solar tip for the user.
@@ -19,14 +20,13 @@ export default function useTip(userId) {
 
     let cancelled = false;
 
-    async function fetchTip() {
+    async function loadTip() {
       try {
         setLoading(true);
         setError(null);
-        const res = await fetch(`http://localhost:8000/tips?user_id=${userId}`);
-        const data = await res.json();
+        const tipText = await fetchTip(userId);
         if (!cancelled) {
-          setTip(data.tip ?? "No tip available right now.");
+          setTip(tipText ?? "No tip available right now.");
         }
       } catch (err) {
         if (!cancelled) {
@@ -38,7 +38,7 @@ export default function useTip(userId) {
       }
     }
 
-    fetchTip();
+    loadTip();
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
## Summary
- useSummary, useTip, and useRoi now call `fetchSummary`, `fetchTip`, and `fetchRoi` from the shared `solarApi` service
- remove hard-coded fetch URLs and continue to guard against state updates after unmount

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 13 errors in unrelated files)*
- `npx eslint src/hooks/useSummary.js src/hooks/useTip.js src/hooks/useRoi.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae0d660220832a97903210a2cd73bc