### PR TITLE
feat: reuse dashboard forecast in chart

### DIFF
--- a/solarpal-frontend/src/components/charts/WeeklyEnergyChart.jsx
+++ b/solarpal-frontend/src/components/charts/WeeklyEnergyChart.jsx
@@ -15,9 +15,11 @@ import {
 // If you prefer to call the backend via your service wrapper:
 import { fetchForecast } from "../../services/solarApi";
 
-export default function WeeklyEnergyChart({ userId, systemSize }) {
-  const [daily, setDaily] = useState([]);
-  const [loading, setLoading] = useState(true);
+export default function WeeklyEnergyChart({ userId, systemSize, forecast }) {
+  const [daily, setDaily] = useState(
+    () => (Array.isArray(forecast?.daily) ? forecast.daily : [])
+  );
+  const [loading, setLoading] = useState(!Array.isArray(forecast?.daily));
   const [err, setErr] = useState("");
   const [isNarrow, setIsNarrow] = useState(false);
   const [isShort, setIsShort] = useState(false);
@@ -39,8 +41,13 @@ export default function WeeklyEnergyChart({ userId, systemSize }) {
   };
 
   useEffect(() => {
-    load();
-  }, [userId, systemSize]);
+    if (Array.isArray(forecast?.daily)) {
+      setDaily(forecast.daily);
+      setLoading(false);
+    } else {
+      load();
+    }
+  }, [userId, systemSize, forecast]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;

--- a/solarpal-frontend/src/components/dashboard/Dashboard.jsx
+++ b/solarpal-frontend/src/components/dashboard/Dashboard.jsx
@@ -132,6 +132,7 @@ function Dashboard({ data, onReset }) {
           <WeeklyEnergyChart
             userId={summary.user_id}
             systemSize={summary.system_size_kw ?? 5}
+            forecast={forecast}
           />
         </ErrorBoundary>
 


### PR DESCRIPTION
## Summary
- pass fetched forecast from Dashboard to WeeklyEnergyChart
- allow WeeklyEnergyChart to skip fetching when forecast data is supplied

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 13 problems, existing errors)
- `npm run build` (fails: Unexpected "{" in TipCard.jsx)


------
https://chatgpt.com/codex/tasks/task_e_68ae0d66cfec832abef8c9fb7245b365