### PR TITLE
Remove unused Button import from ROI card

### DIFF
--- a/solarpal-frontend/src/components/dashboard/ROICard.jsx
+++ b/solarpal-frontend/src/components/dashboard/ROICard.jsx
@@ -1,5 +1,4 @@
 import Card from "../ui/Card";
-import Button from "../ui/Button";
 import useRoi from "../../hooks/useRoi";
 
 export default function ROICard({ userId }) {


### PR DESCRIPTION
## Summary
- remove Button import from ROI card to clean up unused dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 6 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68af8bd3af10832a914c081733662230