### PR TITLE
Remove duplicate SummaryResponse model

### DIFF
--- a/backend/models/summary.py
+++ b/backend/models/summary.py
@@ -1,8 +1,0 @@
-from pydantic import BaseModel
-
-class SummaryResponse(BaseModel):
-    user_id: str
-    daily_saving_gbp: float
-    co2_offset_kg: float
-    battery_status: str
-    message: str


### PR DESCRIPTION
## Summary
- remove redundant `backend/models/summary.py`
- keep `SummaryResponse` model centralized in `backend/models.py`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af8bda8690832a90c4ee8a2abf3e5d